### PR TITLE
fix: support service_outbox event_payload column

### DIFF
--- a/ruva-core/src/adapters/sqlx/postgres.rs
+++ b/ruva-core/src/adapters/sqlx/postgres.rs
@@ -5,6 +5,54 @@ use crate::{
 };
 use sqlx::{PgConnection, PgPool};
 
+const SERVICE_OUTBOX_STATE_COLUMN: &str = "state";
+const SERVICE_OUTBOX_EVENT_PAYLOAD_COLUMN: &str = "event_payload";
+
+fn choose_service_outbox_payload_column(columns: &[String]) -> Option<&'static str> {
+	if columns.iter().any(|column| column == SERVICE_OUTBOX_STATE_COLUMN) {
+		Some(SERVICE_OUTBOX_STATE_COLUMN)
+	} else if columns.iter().any(|column| column == SERVICE_OUTBOX_EVENT_PAYLOAD_COLUMN) {
+		Some(SERVICE_OUTBOX_EVENT_PAYLOAD_COLUMN)
+	} else {
+		None
+	}
+}
+
+fn service_outbox_insert_query(payload_column: &str) -> String {
+	format!(
+		r#"
+            INSERT INTO service_outbox
+                (id, aggregate_id, topic, {payload_column}, aggregate_name, trace_id)
+            SELECT * FROM UNNEST
+                ($1::BIGINT[], $2::text[],  $3::text[], $4::text[], $5::text[], $6::text[])
+            "#
+	)
+}
+
+async fn service_outbox_payload_column(conn: &mut PgConnection) -> Result<&'static str, BaseError> {
+	let columns = sqlx::query_scalar::<_, String>(
+		r#"
+            SELECT attname
+            FROM pg_attribute
+            WHERE attrelid = to_regclass('service_outbox')
+              AND attname IN ('state', 'event_payload')
+              AND NOT attisdropped
+            "#,
+	)
+	.fetch_all(conn)
+	.await
+	.map_err(|err| {
+		tracing::error!("failed to inspect service_outbox payload column! {}", err);
+		BaseError::DatabaseError(err.to_string())
+	})?;
+
+	choose_service_outbox_payload_column(&columns).ok_or_else(|| {
+		let message = "service_outbox requires either state or event_payload column".to_string();
+		tracing::error!("{}", message);
+		BaseError::DatabaseError(message)
+	})
+}
+
 impl Context {
 	pub fn transaction(&mut self) -> &mut PgConnection {
 		match self.pg_transaction.as_mut() {
@@ -16,6 +64,10 @@ impl Context {
 	pub(crate) async fn save_outbox(&mut self) -> Result<(), BaseError> {
 		let outboxes = self.curr_events.iter().filter(|e| e.externally_notifiable()).map(|o| o.outbox()).collect::<Vec<_>>();
 
+		if outboxes.is_empty() {
+			return Ok(());
+		}
+
 		prepare_bulk_operation!(
 			&outboxes,
 			id: i64,
@@ -25,27 +77,56 @@ impl Context {
 			state: String,
 			trace_id: String
 		);
-		sqlx::query(
-			r#"
-            INSERT INTO service_outbox
-                (id, aggregate_id, topic, state, aggregate_name, trace_id)
-            SELECT * FROM UNNEST
-                ($1::BIGINT[], $2::text[],  $3::text[], $4::text[], $5::text[], $6::text[])
-            "#,
-		)
-		.bind(&id)
-		.bind(&aggregate_id)
-		.bind(&topic)
-		.bind(&state)
-		.bind(&aggregate_name)
-		.bind(&trace_id)
-		.execute(self.transaction())
-		.await
-		.map_err(|err| {
-			tracing::error!("failed to insert outbox! {}", err);
-			BaseError::DatabaseError(err.to_string())
-		})?;
+		let payload_column = service_outbox_payload_column(self.transaction()).await?;
+		let query = service_outbox_insert_query(payload_column);
+
+		sqlx::query(&query)
+			.bind(&id)
+			.bind(&aggregate_id)
+			.bind(&topic)
+			.bind(&state)
+			.bind(&aggregate_name)
+			.bind(&trace_id)
+			.execute(self.transaction())
+			.await
+			.map_err(|err| {
+				tracing::error!("failed to insert outbox! {}", err);
+				BaseError::DatabaseError(err.to_string())
+			})?;
 		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn chooses_state_when_state_column_exists() {
+		let columns = vec!["state".to_string(), "event_payload".to_string()];
+
+		assert_eq!(choose_service_outbox_payload_column(&columns), Some("state"));
+	}
+
+	#[test]
+	fn chooses_event_payload_when_state_column_is_missing() {
+		let columns = vec!["event_payload".to_string()];
+
+		assert_eq!(choose_service_outbox_payload_column(&columns), Some("event_payload"));
+	}
+
+	#[test]
+	fn rejects_unknown_payload_columns() {
+		let columns = vec!["payload".to_string()];
+
+		assert_eq!(choose_service_outbox_payload_column(&columns), None);
+	}
+
+	#[test]
+	fn insert_query_uses_selected_payload_column() {
+		let query = service_outbox_insert_query("event_payload");
+
+		assert!(query.contains("(id, aggregate_id, topic, event_payload, aggregate_name, trace_id)"));
 	}
 }
 

--- a/ruva-core/src/adapters/sqlx/postgres.rs
+++ b/ruva-core/src/adapters/sqlx/postgres.rs
@@ -4,9 +4,11 @@ use crate::{
 	prepare_bulk_operation,
 };
 use sqlx::{PgConnection, PgPool};
+use std::sync::OnceLock;
 
 const SERVICE_OUTBOX_STATE_COLUMN: &str = "state";
 const SERVICE_OUTBOX_EVENT_PAYLOAD_COLUMN: &str = "event_payload";
+static SERVICE_OUTBOX_PAYLOAD_COLUMN_CACHE: OnceLock<&'static str> = OnceLock::new();
 
 fn choose_service_outbox_payload_column(columns: &[String]) -> Option<&'static str> {
 	if columns.iter().any(|column| column == SERVICE_OUTBOX_STATE_COLUMN) {
@@ -30,6 +32,10 @@ fn service_outbox_insert_query(payload_column: &str) -> String {
 }
 
 async fn service_outbox_payload_column(conn: &mut PgConnection) -> Result<&'static str, BaseError> {
+	if let Some(column) = SERVICE_OUTBOX_PAYLOAD_COLUMN_CACHE.get().copied() {
+		return Ok(column);
+	}
+
 	let columns = sqlx::query_scalar::<_, String>(
 		r#"
             SELECT attname
@@ -46,11 +52,14 @@ async fn service_outbox_payload_column(conn: &mut PgConnection) -> Result<&'stat
 		BaseError::DatabaseError(err.to_string())
 	})?;
 
-	choose_service_outbox_payload_column(&columns).ok_or_else(|| {
+	let column = choose_service_outbox_payload_column(&columns).ok_or_else(|| {
 		let message = "service_outbox requires either state or event_payload column".to_string();
 		tracing::error!("{}", message);
 		BaseError::DatabaseError(message)
-	})
+	})?;
+
+	let _ = SERVICE_OUTBOX_PAYLOAD_COLUMN_CACHE.set(column);
+	Ok(SERVICE_OUTBOX_PAYLOAD_COLUMN_CACHE.get().copied().unwrap_or(column))
 }
 
 impl Context {

--- a/ruva-core/src/adapters/sqlx/postgres.rs
+++ b/ruva-core/src/adapters/sqlx/postgres.rs
@@ -8,37 +8,66 @@ use std::sync::OnceLock;
 
 const SERVICE_OUTBOX_STATE_COLUMN: &str = "state";
 const SERVICE_OUTBOX_EVENT_PAYLOAD_COLUMN: &str = "event_payload";
-static SERVICE_OUTBOX_PAYLOAD_COLUMN_CACHE: OnceLock<&'static str> = OnceLock::new();
+const SERVICE_OUTBOX_TEXT_CAST: &str = "text";
+const SERVICE_OUTBOX_JSON_CAST: &str = "json";
+const SERVICE_OUTBOX_JSONB_CAST: &str = "jsonb";
 
-fn choose_service_outbox_payload_column(columns: &[String]) -> Option<&'static str> {
-	if columns.iter().any(|column| column == SERVICE_OUTBOX_STATE_COLUMN) {
-		Some(SERVICE_OUTBOX_STATE_COLUMN)
-	} else if columns.iter().any(|column| column == SERVICE_OUTBOX_EVENT_PAYLOAD_COLUMN) {
-		Some(SERVICE_OUTBOX_EVENT_PAYLOAD_COLUMN)
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct ServiceOutboxPayloadColumn {
+	name: &'static str,
+	cast_type: &'static str,
+}
+
+static SERVICE_OUTBOX_PAYLOAD_COLUMN_CACHE: OnceLock<ServiceOutboxPayloadColumn> = OnceLock::new();
+
+fn service_outbox_payload_cast_type(data_type: &str) -> &'static str {
+	match data_type {
+		SERVICE_OUTBOX_JSON_CAST => SERVICE_OUTBOX_JSON_CAST,
+		SERVICE_OUTBOX_JSONB_CAST => SERVICE_OUTBOX_JSONB_CAST,
+		_ => SERVICE_OUTBOX_TEXT_CAST,
+	}
+}
+
+fn choose_service_outbox_payload_column(columns: &[(String, String)]) -> Option<ServiceOutboxPayloadColumn> {
+	if columns.iter().any(|(column, _)| column == SERVICE_OUTBOX_STATE_COLUMN) {
+		Some(ServiceOutboxPayloadColumn {
+			name: SERVICE_OUTBOX_STATE_COLUMN,
+			cast_type: SERVICE_OUTBOX_TEXT_CAST,
+		})
+	} else if let Some((_, data_type)) = columns.iter().find(|(column, _)| column == SERVICE_OUTBOX_EVENT_PAYLOAD_COLUMN) {
+		Some(ServiceOutboxPayloadColumn {
+			name: SERVICE_OUTBOX_EVENT_PAYLOAD_COLUMN,
+			cast_type: service_outbox_payload_cast_type(data_type),
+		})
 	} else {
 		None
 	}
 }
 
-fn service_outbox_insert_query(payload_column: &str) -> String {
+fn service_outbox_insert_query(payload_column: ServiceOutboxPayloadColumn) -> String {
+	let payload_column_name = payload_column.name;
+	let payload_cast_type = payload_column.cast_type;
+
 	format!(
 		r#"
             INSERT INTO service_outbox
-                (id, aggregate_id, topic, {payload_column}, aggregate_name, trace_id)
-            SELECT * FROM UNNEST
+                (id, aggregate_id, topic, {payload_column_name}, aggregate_name, trace_id)
+            SELECT id, aggregate_id, topic, payload::{payload_cast_type}, aggregate_name, trace_id
+            FROM UNNEST
                 ($1::BIGINT[], $2::text[],  $3::text[], $4::text[], $5::text[], $6::text[])
+                AS outbox(id, aggregate_id, topic, payload, aggregate_name, trace_id)
             "#
 	)
 }
 
-async fn service_outbox_payload_column(conn: &mut PgConnection) -> Result<&'static str, BaseError> {
+async fn service_outbox_payload_column(conn: &mut PgConnection) -> Result<ServiceOutboxPayloadColumn, BaseError> {
 	if let Some(column) = SERVICE_OUTBOX_PAYLOAD_COLUMN_CACHE.get().copied() {
 		return Ok(column);
 	}
 
-	let columns = sqlx::query_scalar::<_, String>(
+	let columns = sqlx::query_as::<_, (String, String)>(
 		r#"
-            SELECT attname
+            SELECT attname, atttypid::regtype::text AS data_type
             FROM pg_attribute
             WHERE attrelid = to_regclass('service_outbox')
               AND attname IN ('state', 'event_payload')
@@ -112,30 +141,67 @@ mod tests {
 
 	#[test]
 	fn chooses_state_when_state_column_exists() {
-		let columns = vec!["state".to_string(), "event_payload".to_string()];
+		let columns = vec![("state".to_string(), "text".to_string()), ("event_payload".to_string(), "jsonb".to_string())];
 
-		assert_eq!(choose_service_outbox_payload_column(&columns), Some("state"));
+		assert_eq!(choose_service_outbox_payload_column(&columns), Some(ServiceOutboxPayloadColumn { name: "state", cast_type: "text" }));
 	}
 
 	#[test]
-	fn chooses_event_payload_when_state_column_is_missing() {
-		let columns = vec!["event_payload".to_string()];
+	fn chooses_text_event_payload_when_state_column_is_missing() {
+		let columns = vec![("event_payload".to_string(), "text".to_string())];
 
-		assert_eq!(choose_service_outbox_payload_column(&columns), Some("event_payload"));
+		assert_eq!(
+			choose_service_outbox_payload_column(&columns),
+			Some(ServiceOutboxPayloadColumn {
+				name: "event_payload",
+				cast_type: "text",
+			})
+		);
+	}
+
+	#[test]
+	fn chooses_json_event_payload_when_state_column_is_missing() {
+		let columns = vec![("event_payload".to_string(), "json".to_string())];
+
+		assert_eq!(
+			choose_service_outbox_payload_column(&columns),
+			Some(ServiceOutboxPayloadColumn {
+				name: "event_payload",
+				cast_type: "json",
+			})
+		);
+	}
+
+	#[test]
+	fn chooses_jsonb_event_payload_when_state_column_is_missing() {
+		let columns = vec![("event_payload".to_string(), "jsonb".to_string())];
+
+		assert_eq!(
+			choose_service_outbox_payload_column(&columns),
+			Some(ServiceOutboxPayloadColumn {
+				name: "event_payload",
+				cast_type: "jsonb",
+			})
+		);
 	}
 
 	#[test]
 	fn rejects_unknown_payload_columns() {
-		let columns = vec!["payload".to_string()];
+		let columns = vec![("payload".to_string(), "jsonb".to_string())];
 
 		assert_eq!(choose_service_outbox_payload_column(&columns), None);
 	}
 
 	#[test]
 	fn insert_query_uses_selected_payload_column() {
-		let query = service_outbox_insert_query("event_payload");
+		let query = service_outbox_insert_query(ServiceOutboxPayloadColumn {
+			name: "event_payload",
+			cast_type: "jsonb",
+		});
 
 		assert!(query.contains("(id, aggregate_id, topic, event_payload, aggregate_name, trace_id)"));
+		assert!(query.contains("payload::jsonb"));
+		assert!(query.contains("$4::text[]"));
 	}
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,8 +58,7 @@
 //! ```
 //! Note that use of `internally_notifiable`(or `externally_notifiable`) and `identifier` are MUST.
 //!
-//! * `internally_notifiable` is marker to let the system know that the event should be handled
-//!    within the application
+//! * `internally_notifiable` is marker to let the system know that the event should be handled within the application
 //! * `externally_notifiable` is to leave `OutBox`.
 //! * `identifier` is to record aggregate id.
 //!


### PR DESCRIPTION
## Summary
- Detect whether `service_outbox` exposes `state` or `event_payload` at runtime.
- Keep `state` as the preferred column when both exist, preserving the existing Terra contract.
- Insert external outbox events into `event_payload` when `state` is absent.
- Skip the outbox insert path when there are no externally notifiable events.

## Why
Some customer DB environments expose the serialized outbox payload column as `event_payload` instead of `state`, and the DB structure cannot be changed. `ruva` is the common outbox writer, so compatibility belongs here first.

## Validation
- `cargo fmt --all --check`
- `cargo test --features sqlx-postgres --lib` from `ruva-core`
- `cargo test --features sqlx-postgres` from repository root